### PR TITLE
Better syntax for adding events to changeset

### DIFF
--- a/lib/akasha/aggregate.rb
+++ b/lib/akasha/aggregate.rb
@@ -8,7 +8,7 @@ module Akasha
   #
   # class User < Akasha::Aggregate
   #   def sign_up(email, password)
-  #     changeset << Akasha::Event.new(:user_signed_up, email: email, password: password)
+  #     changeset.append(:user_signed_up, email: email, password: password)
   #   end
   #
   #   def on_user_signed_up(email:, password:, **_)

--- a/lib/akasha/changeset.rb
+++ b/lib/akasha/changeset.rb
@@ -10,8 +10,8 @@ module Akasha
     end
 
     # Adds an event to the changeset.
-    def append(event, **data)
-      @events << Akasha::Event.new(event, **data)
+    def append(event_name, **data)
+      @events << Akasha::Event.new(event_name, **data)
     end
   end
 end

--- a/lib/akasha/changeset.rb
+++ b/lib/akasha/changeset.rb
@@ -10,8 +10,8 @@ module Akasha
     end
 
     # Adds an event to the changeset.
-    def <<(event)
-      @events << event
+    def append(event, **data)
+      @events << Akasha::Event.new(event, **data)
     end
   end
 end

--- a/spec/fixtures/item.rb
+++ b/spec/fixtures/item.rb
@@ -2,7 +2,7 @@ class Item < Akasha::Aggregate
   attr_reader :name
 
   def name=(new_name)
-    changeset << Akasha::Event.new(:name_changed, old_name: @name, new_name: new_name)
+    changeset.append(:name_changed, old_name: @name, new_name: new_name)
   end
 
   def on_name_changed(new_name:, **)


### PR DESCRIPTION
```ruby
    changeset.append(:name_changed, old_name: @name, new_name: new_name)
```

instead of 

```ruby
    changeset << Akasha::Event.new(:name_changed, old_name: @name, new_name: new_name)
```