### PR TITLE
Add support for command routing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (10.0.2)
+    coderay (1.1.2)
     diff-lcs (1.3)
+    method_source (0.9.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     rake (10.5.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -29,6 +38,7 @@ PLATFORMS
 DEPENDENCIES
   akasha!
   bundler (~> 1.16)
+  pry-byebug
   rake (~> 10.0)
   rspec (~> 3.7)
   timecop

--- a/akasha.gemspec
+++ b/akasha.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'timecop'
+  spec.add_development_dependency 'pry-byebug'
 end

--- a/lib/akasha.rb
+++ b/lib/akasha.rb
@@ -1,4 +1,5 @@
 require 'akasha/event'
 require 'akasha/aggregate'
+require 'akasha/command_router'
 require 'akasha/repository'
 require 'akasha/storage/memory_event_store'

--- a/lib/akasha/aggregate/syntax_helpers.rb
+++ b/lib/akasha/aggregate/syntax_helpers.rb
@@ -38,7 +38,9 @@ module Akasha
     module InstanceMethods
       # Saves the aggregate.
       def save!
+        return if changeset.empty?
         self.class.repository.save_aggregate(self)
+        changeset.clear!
       end
     end
   end

--- a/lib/akasha/changeset.rb
+++ b/lib/akasha/changeset.rb
@@ -13,5 +13,15 @@ module Akasha
     def <<(event)
       @events << event
     end
+
+    # Returns true if no changes recorded.
+    def empty?
+      @events.empty?
+    end
+
+    # Clears the changeset.
+    def clear!
+      @events = []
+    end
   end
 end

--- a/lib/akasha/command_router.rb
+++ b/lib/akasha/command_router.rb
@@ -1,0 +1,36 @@
+require_relative 'command_router/default_handler'
+
+module Akasha
+  # Routes commands to their handlers.
+  class CommandRouter
+    # Raised when no corresponding target can be found for a command.
+    NotFoundError = Class.new(RuntimeError)
+
+    def initialize
+      @routes = {}
+    end
+
+    # Registers a custom route, specifying either a lambda or a block.
+    # If both lambda and block are specified, lambda takes precedence.
+    def register_route(command, lambda = nil, &block)
+      callable = lambda || block
+      @routes[command] = callable
+    end
+
+    # Registers a default route, mapping a command to an aggregate class.
+    # As a result, when `#route!` is called for that command, the aggregate
+    # will be loaded from repository, the command will be sent to the object
+    # to invoke the object's method, and finally the aggregate will be saved.
+    def register_default_route(command, aggregate_class)
+      register_route(command, DefaultHandler.new(aggregate_class))
+    end
+
+    # Routes a command to the registered target.
+    # Raises NotFoundError if no corresponding target can be found.
+    def route!(command, aggregate_id, **data)
+      handler = @routes[command]
+      return handler.call(command, aggregate_id, **data) if handler
+      raise NotFoundError, "Target for command #{command.inspect} not found"
+    end
+  end
+end

--- a/lib/akasha/command_router/default_handler.rb
+++ b/lib/akasha/command_router/default_handler.rb
@@ -1,0 +1,19 @@
+module Akasha
+  class CommandRouter
+    # Default command handler.
+    # Works by loading aggregate from the repo by id,
+    # invoking its method `command`, passing all data,
+    # and saving changes to the aggregate in the end.
+    class DefaultHandler
+      def initialize(klass)
+        @klass = klass
+      end
+
+      def call(command, aggregate_id, **data)
+        aggregate = @klass.find_or_create(aggregate_id)
+        aggregate.public_send(command, **data)
+        aggregate.save!
+      end
+    end
+  end
+end

--- a/spec/akasha/aggregate/syntax_helpers_spec.rb
+++ b/spec/akasha/aggregate/syntax_helpers_spec.rb
@@ -1,0 +1,37 @@
+describe Akasha::SyntaxHelpers do
+  subject { Item.new('item-1') }
+  let(:repo) { Akasha::Repository.new(Akasha::Storage::MemoryEventStore.new) }
+
+  before do
+    Akasha::Aggregate.connect!(repo)
+  end
+
+  describe '#find_or_create' do
+    it 'creates new aggregate' do
+      item = Item.find_or_create('item-1')
+      expect(item).to_not be_nil
+      expect(item).to be_an Item
+    end
+
+    it 'finds existing aggregate' do
+      item = Item.find_or_create('item-1')
+      item.name = 'new name'
+      item.save!
+
+      item = Item.find_or_create('item-1')
+      expect(item).to_not be_nil
+      expect(item).to be_an Item
+      expect(item.name).to eq('new name')
+    end
+  end
+
+  describe '#save!' do
+    it 'persists changes to a modified aggregate' do
+      subject.name = 'new name'
+      expect { subject.save! }.to_not raise_error
+
+      item = Item.find_or_create('item-1')
+      expect(item.name).to eq('new name')
+    end
+  end
+end

--- a/spec/akasha/aggregate/syntax_helpers_spec.rb
+++ b/spec/akasha/aggregate/syntax_helpers_spec.rb
@@ -33,5 +33,13 @@ describe Akasha::SyntaxHelpers do
       item = Item.find_or_create('item-1')
       expect(item.name).to eq('new name')
     end
+
+    it 'ignores subsequent saves without further modifications' do
+      expect(repo).to receive(:save_aggregate).once
+      subject.name = 'new name'
+      subject.save!
+      subject.save!
+      subject.save!
+    end
   end
 end

--- a/spec/akasha/command_router_spec.rb
+++ b/spec/akasha/command_router_spec.rb
@@ -1,0 +1,54 @@
+describe Akasha::CommandRouter do
+  let(:router) { described_class.new }
+  let(:repo) { Akasha::Repository.new(Akasha::Storage::MemoryEventStore.new) }
+
+  before do
+    Akasha::Aggregate.connect!(repo)
+  end
+
+  describe '#route!' do
+    subject { router.route!(:change_item_name, 'item-1', new_name: 'new name') }
+
+    context 'without valid target' do
+      it 'raises error' do
+        expect { subject }.to raise_error Akasha::CommandRouter::NotFoundError
+      end
+    end
+
+    context 'with valid default target' do
+      before do
+        router.register_default_route(:change_item_name, Item)
+      end
+
+      it 'raises no error' do
+        expect { subject }.to_not raise_error
+      end
+
+      it 'persists changes to the aggregate' do
+        router.route!(:change_item_name, 'item-1', new_name: 'new name')
+        item = Item.find_or_create('item-1')
+        expect(item.name).to eq 'new name'
+      end
+    end
+
+    context 'with valid custom target' do
+      before do
+        router.register_route(:change_item_name) do |command, aggregate_id, **data|
+          item = Item.find_or_create(aggregate_id)
+          item.name = data[:new_name]
+          item.save!
+        end
+      end
+
+      it 'raises no error' do
+        expect { subject }.to_not raise_error
+      end
+
+      it 'persists changes to the aggregate' do
+        router.route!(:change_item_name, 'item-1', new_name: 'new name')
+        item = Item.find_or_create('item-1')
+        expect(item.name).to eq 'new name'
+      end
+    end
+  end
+end

--- a/spec/akasha/integration_spec.rb
+++ b/spec/akasha/integration_spec.rb
@@ -1,4 +1,4 @@
-describe 'handling commands' do
+describe 'routing commands' do
   let(:repo) { Akasha::Repository.new(Akasha::Storage::MemoryEventStore.new) }
 
   before do

--- a/spec/fixtures/item.rb
+++ b/spec/fixtures/item.rb
@@ -1,10 +1,17 @@
 class Item < Akasha::Aggregate
   attr_reader :name
 
+  # Attribute accessors can use events too!
   def name=(new_name)
     changeset << Akasha::Event.new(:name_changed, old_name: @name, new_name: new_name)
   end
 
+  # Alias for default command routing.
+  def change_item_name(new_name:, **)
+    self.name = new_name # This will generate the event!
+  end
+
+  # This is how you apply events to build aggregate state.
   def on_name_changed(new_name:, **)
     @name = new_name
   end


### PR DESCRIPTION
Full example from the README:

```ruby
require 'akasha'
require 'sinatra'

class User < Akasha::Aggregate
  def sign_up(email:, password:, admin: false, **)
    changeset << Akasha::Event.new(:user_signed_up, email: email, password: password, admin: admin)
  end

  def on_user_signed_up(email:, password:, admin:, **)
    @email = email
    @password = password
    @admin = admin
  end
end


before do
  @router = Akasha::CommandRouter.new

  # Aggregates will load from and save to in-memory storage.
  repository = Akasha::Repository.new(Akasha::Storage::MemoryEventStore.new)
  Akasha::Aggregate.connect!(repository)

  # This is how you link commands to aggregates.
  @router.register_default_route(:sign_up, User)

  # Nearly identital to the default handling above but we're setting the admin
  # flag to demo custom command handling.
  @router.register_route(:sign_up_admin) do |aggregate_id, **data|
    user = User.find_or_create(aggregate_id)
    user.sign_up(email: data[:email], password: data[:password], admin: true)
    user.save!
  end
end

post '/users/:user_id' do # With CQRS client pass unique aggregate ids.
  @router.route!(:sign_up,
                 params[:user_id],
                 email: params[:email],
                 password: params[:password])
  'OK'
end
```