### PR TITLE
Refactor API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akasha (0.2.0)
+    akasha (0.3.0)
       corefines (~> 1.11)
       faraday (~> 0.15)
       faraday_middleware

--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ This library itself makes no assumptions about any web framework, you can use it
   - [x] Simplify AsyncEventRouter init
   - [x] SyncEventRouter => EventRouter
   - [x] Metadata not persisted
-- [ ] Refactoring & simplification.
+- [x] Refactoring & simplification.
   - [x] Hash-based event and command router
-  - [ ] Do we need EventListener class?
-  - [ ] Assymetry between data and metadata.
-  - [ ] Faster shutdown.
+  - [x] Do we need EventListener class? Yes.
   - [x] Assymetry between data and metadata.
+  - [x] Faster shutdown.
 - [ ] Namespacing for events and aggregates and the projection
 - [ ] Version-based concurrency
 - [ ] Telemetry (Dogstatsd)

--- a/README.md
+++ b/README.md
@@ -20,65 +20,16 @@ Or install it yourself as:
 
 ## Usage
 
-The code below uses Sinatra to demonstrate how to use the library in a web application.
-This library makes no assumptions about any web framework, you can use it in any way you see fit.
+There is an example Sinatra app under `examples/sinatra` showing how to use the library in a web application.
+This library itself makes no assumptions about any web framework, you can use it in any way you see fit.
 
-```ruby
-require 'akasha'
-require 'sinatra'
-
-class User < Akasha::Aggregate
-  def sign_up(email:, password:, admin: false, **)
-    changeset.append(:user_signed_up, email: email, password: password, admin: admin)
-  end
-
-  def on_user_signed_up(email:, password:, admin:, **)
-    @email = email
-    @password = password
-    @admin = admin
-  end
-end
-
-
-before do
-  @router = Akasha::CommandRouter.new
-
-  # Aggregates will load from and save to in-memory storage.
-  repository = Akasha::Repository.new(Akasha::Storage::MemoryEventStore.new)
-  Akasha::Aggregate.connect!(repository)
-
-  # This is how you link commands to aggregates.
-  @router.register_default_route(:sign_up, User)
-
-  # Nearly identital to the default handling above but we're setting the admin
-  # flag to demo custom command handling.
-  @router.register_route(:sign_up_admin) do |aggregate_id, **data|
-    user = User.find_or_create(aggregate_id)
-    user.sign_up(email: data[:email], password: data[:password], admin: true)
-    user.save!
-  end
-end
-
-post '/users/:user_id' do # With CQRS client pass unique aggregate ids.
-  @router.route!(:sign_up,
-                 params[:user_id],
-                 email: params[:email],
-                 password: params[:password])
-  'OK'
-end
-```
-
-> Currently, only memory-based repository is supported.
-
-## Next steps
+## TODO
 
 - [x] Command routing (default and user-defined)
 - [x] Synchronous EventHandler
 - [x] HTTP Eventstore storage backend
-- [ ] Namespacing for events and aggregates and the projection
-- [ ] Event#id for better idempotence (validate this claim)
-- [ ] Version-based concurrency
-- [ ] Async EventHandlers (storing cursors in Eventstore, configurable durability guarantees)
+- [x] Event#id for better idempotence (validate this claim)
+- [x] Async EventHandlers (storing cursors in Eventstore, configurable durability guarantees)
   - [x] Uniform intetrface for Client -- use Event.
   - [x] Rewrite Client
   - [x] Refactor Client code
@@ -90,8 +41,13 @@ end
   - [x] Simplify AsyncEventRouter init
   - [x] SyncEventRouter => EventRouter
   - [x] Metadata not persisted
+- [ ] Refactoring & simplification.
+  - [x] Hash-based event and command router
+  - [ ] Do we need EventListener class?
   - [ ] Assymetry between data and metadata.
   - [ ] Faster shutdown.
+- [ ] Namespacing for events and aggregates and the projection
+- [ ] Version-based concurrency
 - [ ] Telemetry (Dogstatsd)
 - [ ] Socket-based Eventstore storage backend
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This library itself makes no assumptions about any web framework, you can use it
   - [ ] Do we need EventListener class?
   - [ ] Assymetry between data and metadata.
   - [ ] Faster shutdown.
+  - [x] Assymetry between data and metadata.
 - [ ] Namespacing for events and aggregates and the projection
 - [ ] Version-based concurrency
 - [ ] Telemetry (Dogstatsd)

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -50,9 +50,15 @@ class MyAkashaApp
 
   attr_accessor :command_router
 
-  def initialize
+  def initialize # rubocop:disable Metrics/MethodLength
     # Aggregates will load from and save to in-memory storage.
-    repository = Akasha::Repository.new(Akasha::Storage::HttpEventStore.new(username: 'admin', password: 'changeit'), namespace: :my_app)
+    repository = Akasha::Repository.new(
+      Akasha::Storage::HttpEventStore.new(
+        username: 'admin',
+        password: 'changeit'
+      ),
+      namespace: :my_app
+    )
     Akasha::Aggregate.connect!(repository)
 
     # Set up event listeners.
@@ -68,7 +74,7 @@ class MyAkashaApp
 
     @command_router = Akasha::CommandRouter.new(
       sign_up: User,
-      sign_up_admin: ->(aggregate_id, **data) {
+      sign_up_admin: lambda { |aggregate_id, **data|
         user = User.find_or_create(aggregate_id)
         user.sign_up(email: data[:email], password: data[:password], admin: true)
         user.save!

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -50,33 +50,30 @@ class MyAkashaApp
 
   attr_accessor :command_router
 
-  # rubocop:disable Metrics/AbcSize
   def initialize
-    @command_router = Akasha::CommandRouter.new
-
     # Aggregates will load from and save to in-memory storage.
-    repository = Akasha::Repository.new(Akasha::Storage::HttpEventStore.new(username: 'admin', password: 'changeit'))
+    repository = Akasha::Repository.new(Akasha::Storage::HttpEventStore.new(username: 'admin', password: 'changeit'), namespace: :my_app)
     Akasha::Aggregate.connect!(repository)
 
     # Set up event listeners.
-    event_router = Akasha::EventRouter.new
-    event_router.register_event_listener(:user_signed_up, UserListMaterializer)
+    event_router = Akasha::EventRouter.new(
+      user_signed_up: UserListMaterializer
+    )
     event_router.connect!(repository)
 
-    async_event_router = Akasha::AsyncEventRouter.new
-    async_event_router.register_event_listener(:user_signed_up, Notifier)
+    async_event_router = Akasha::AsyncEventRouter.new(
+      user_signed_up: Notifier
+    )
     async_event_router.connect!(repository) # Returns Thread instance.
 
-    # This is how you link commands to aggregates.
-    @command_router.register_default_route(:sign_up, User)
-
-    # Nearly identital to the default handling above but we're setting the admin
-    # flag to demo custom command handling.
-    @command_router.register_route(:sign_up_admin) do |aggregate_id, **data|
-      user = User.find_or_create(aggregate_id)
-      user.sign_up(email: data[:email], password: data[:password], admin: true)
-      user.save!
-    end
+    @command_router = Akasha::CommandRouter.new(
+      sign_up: User,
+      sign_up_admin: ->(aggregate_id, **data) {
+        user = User.find_or_create(aggregate_id)
+        user.sign_up(email: data[:email], password: data[:password], admin: true)
+        user.save!
+      }
+    )
   end
 end
 
@@ -84,9 +81,6 @@ helpers do
   def route_command(*args)
     MyAkashaApp.instance.command_router.route!(*args)
   end
-end
-
-configure do
 end
 
 post '/users/:user_id' do # With CQRS client pass unique aggregate ids.

--- a/lib/akasha/async_event_router.rb
+++ b/lib/akasha/async_event_router.rb
@@ -5,7 +5,7 @@ module Akasha
   # Event router working that can run in the background, providing eventual
   # consistency. Can use the same EventListeners as the synchronous EventRouter.
   class AsyncEventRouter < EventRouterBase
-    DEFAULT_POLL_SECONDS = 10
+    DEFAULT_POLL_SECONDS = 2
     DEFAULT_PAGE_SIZE = 20
     DEFAULT_PROJECTION_STREAM = 'AsyncEventRouter'.freeze
     DEFAULT_CHECKPOINT_STRATEGY = Akasha::Checkpoint::HttpEventStoreCheckpoint
@@ -30,7 +30,7 @@ module Akasha
         projection_stream.read_events(position, page_size, poll) do |events|
           begin
             events.each do |event|
-              route(event.name, event.metadata.aggregate_id, **event.data)
+              route(event.name, event.metadata[:aggregate_id], **event.data)
               position = checkpoint.ack(position)
             end
           rescue RuntimeError => e

--- a/lib/akasha/changeset.rb
+++ b/lib/akasha/changeset.rb
@@ -11,8 +11,8 @@ module Akasha
 
     # Adds an event to the changeset.
     def append(event_name, **data)
-      event = Akasha::Event.new(event_name, **data)
-      event.metadata.aggregate_id = @aggregate_id
+      id = SecureRandom.uuid
+      event = Akasha::Event.new(event_name, id, { aggregate_id: @aggregate_id }, **data)
       @events << event
     end
 

--- a/lib/akasha/command_router.rb
+++ b/lib/akasha/command_router.rb
@@ -1,13 +1,22 @@
 require_relative 'command_router/default_handler'
+require 'corefines/hash'
 
 module Akasha
   # Routes commands to their handlers.
   class CommandRouter
+    using Corefines::Hash
+
     # Raised when no corresponding target can be found for a command.
     NotFoundError = Class.new(RuntimeError)
 
-    def initialize
-      @routes = {}
+    def initialize(routes = {})
+      @routes = routes.flat_map do |command, target|
+        if target.is_a?(Class)
+          { command => DefaultHandler.new(target) }
+        else
+          { command => target }
+        end
+      end
     end
 
     # Registers a custom route, specifying either a lambda or a block.

--- a/lib/akasha/event.rb
+++ b/lib/akasha/event.rb
@@ -1,4 +1,3 @@
-require 'ostruct'
 require 'securerandom'
 require 'time'
 
@@ -7,10 +6,10 @@ module Akasha
   class Event
     attr_reader :id, :name, :data, :metadata
 
-    def initialize(name, id = nil, metadata = OpenStruct.new, **data)
+    def initialize(name, id = nil, metadata = {}, **data)
       @id = id || SecureRandom.uuid.to_s # TODO: Use something better.
       @name = name
-      @metadata = metadata || OpenStruct.new(created_at: Time.now.utc)
+      @metadata = metadata || { created_at: Time.now.utc }
       @data = data
     end
 

--- a/lib/akasha/event_router_base.rb
+++ b/lib/akasha/event_router_base.rb
@@ -1,23 +1,21 @@
 module Akasha
   # Base class for routing events to event listeners.
   class EventRouterBase
-    def initialize
+    def initialize(routes = {})
       @routes = Hash.new { |hash, key| hash[key] = [] }
+      @routes.merge!(routes)
     end
 
     # Registers a new event listener, derived from
     # `Akasha::EventListener`.
     def register_event_listener(event_name, listener)
-      @routes[event_name] << if listener.is_a?(Class)
-                               listener.new
-                             else
-                               listener
-                             end
+      @routes[event_name] << listener
     end
 
     # Routes an event.
     def route(event_name, aggregate_id, **data)
       @routes[event_name].each do |listener|
+        listener = listener.new if listener.is_a?(Class)
         begin
           listener.public_send(:"on_#{event_name}", aggregate_id, **data)
         rescue RuntimeError => e

--- a/lib/akasha/storage/http_event_store/event_serializer.rb
+++ b/lib/akasha/storage/http_event_store/event_serializer.rb
@@ -13,7 +13,7 @@ module Akasha
             base = {
               'eventType' => event.name,
               'data' => event.data,
-              'metaData' => event.metadata.to_h
+              'metaData' => event.metadata
             }
             base['eventId'] = event.id unless event.id.nil?
             base
@@ -24,7 +24,7 @@ module Akasha
           es_events.map do |ev|
             metadata = ev['metaData']&.symbolize_keys || {}
             data = ev['data']&.symbolize_keys || {}
-            event = Akasha::Event.new(ev['eventType'].to_sym, ev['eventId'], OpenStruct.new(metadata), **data)
+            event = Akasha::Event.new(ev['eventType'].to_sym, ev['eventId'], metadata, **data)
             event
           end
         end

--- a/lib/akasha/version.rb
+++ b/lib/akasha/version.rb
@@ -1,3 +1,3 @@
 module Akasha
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/spec/akasha/command_router_spec.rb
+++ b/spec/akasha/command_router_spec.rb
@@ -6,6 +6,18 @@ describe Akasha::CommandRouter do
     Akasha::Aggregate.connect!(repo)
   end
 
+  shared_examples 'routes registered command' do
+    it 'raises no error' do
+      expect { subject }.to_not raise_error
+    end
+
+    it 'persists changes to the aggregate' do
+      router.route!(:change_item_name, 'item-1', new_name: 'new name')
+      item = Item.find_or_create('item-1')
+      expect(item.name).to eq 'new name'
+    end
+  end
+
   describe '#route!' do
     subject { router.route!(:change_item_name, 'item-1', new_name: 'new name') }
 
@@ -20,15 +32,7 @@ describe Akasha::CommandRouter do
         router.register_default_route(:change_item_name, Item)
       end
 
-      it 'raises no error' do
-        expect { subject }.to_not raise_error
-      end
-
-      it 'persists changes to the aggregate' do
-        router.route!(:change_item_name, 'item-1', new_name: 'new name')
-        item = Item.find_or_create('item-1')
-        expect(item.name).to eq 'new name'
-      end
+      include_examples 'routes registered command'
     end
 
     context 'with valid custom target' do
@@ -40,15 +44,25 @@ describe Akasha::CommandRouter do
         end
       end
 
-      it 'raises no error' do
-        expect { subject }.to_not raise_error
+      include_examples 'routes registered command'
+    end
+
+    context 'with valid default target registered via constructor' do
+      let(:router) { described_class.new(change_item_name: Item) }
+
+      include_examples 'routes registered command'
+    end
+
+    context 'with valid custom target registered via constructor' do
+      let(:router) do
+        described_class.new(change_item_name: lambda do |_command, aggregate_id, **data|
+            item = Item.find_or_create(aggregate_id)
+            item.name = data[:new_name]
+            item.save!
+        end)
       end
 
-      it 'persists changes to the aggregate' do
-        router.route!(:change_item_name, 'item-1', new_name: 'new name')
-        item = Item.find_or_create('item-1')
-        expect(item.name).to eq 'new name'
-      end
+      include_examples 'routes registered command'
     end
   end
 end

--- a/spec/akasha/command_router_spec.rb
+++ b/spec/akasha/command_router_spec.rb
@@ -56,9 +56,9 @@ describe Akasha::CommandRouter do
     context 'with valid custom target registered via constructor' do
       let(:router) do
         described_class.new(change_item_name: lambda do |_command, aggregate_id, **data|
-            item = Item.find_or_create(aggregate_id)
-            item.name = data[:new_name]
-            item.save!
+          item = Item.find_or_create(aggregate_id)
+          item.name = data[:new_name]
+          item.save!
         end)
       end
 

--- a/spec/akasha/event_router_base_spec.rb
+++ b/spec/akasha/event_router_base_spec.rb
@@ -6,6 +6,26 @@ describe Akasha::EventRouterBase do
     Akasha::Aggregate.connect!(repo)
   end
 
+  shared_examples 'routes registered events' do
+    before do
+      allow(router).to receive(:log).and_return(nil) # Do not print to stdout.
+    end
+
+    it 'invokes all event handlers' do
+      expect_any_instance_of(Notifier).to receive(:on_name_changed).with('item-1', new_name: 'new name')
+      expect_any_instance_of(ItemLogger).to receive(:on_name_changed).with('item-1', new_name: 'new name')
+      expect { subject }.to_not raise_error
+    end
+
+    it 'ignores exceptions' do
+      expect_any_instance_of(Notifier).to receive(:on_name_changed).with('item-1', new_name: 'new name')
+        .and_raise('Oops!')
+      expect_any_instance_of(ItemLogger).to receive(:on_name_changed).with('item-1', new_name: 'new name')
+        .and_raise('Oops!')
+      expect { subject }.to_not raise_error
+    end
+  end
+
   describe '#route' do
     subject { router.route(:name_changed, 'item-1', new_name: 'new name') }
 
@@ -43,22 +63,17 @@ describe Akasha::EventRouterBase do
       before do
         router.register_event_listener(:name_changed, Notifier)
         router.register_event_listener(:name_changed, ItemLogger)
-        allow(router).to receive(:log).and_return(nil) # Do not print to stdout.
       end
 
-      it 'invokes all event handlers' do
-        expect_any_instance_of(Notifier).to receive(:on_name_changed).with('item-1', new_name: 'new name')
-        expect_any_instance_of(ItemLogger).to receive(:on_name_changed).with('item-1', new_name: 'new name')
-        expect { subject }.to_not raise_error
+      include_examples 'routes registered events'
+    end
+
+    context 'with multiple valid listeners passed to constructor' do
+      let(:router) do
+        described_class.new(name_changed: [Notifier, ItemLogger])
       end
 
-      it 'ignores exceptions' do
-        expect_any_instance_of(Notifier).to receive(:on_name_changed).with('item-1', new_name: 'new name')
-                                                                     .and_raise('Oops!')
-        expect_any_instance_of(ItemLogger).to receive(:on_name_changed).with('item-1', new_name: 'new name')
-                                                                       .and_raise('Oops!')
-        expect { subject }.to_not raise_error
-      end
+      include_examples 'routes registered events'
     end
   end
 end

--- a/spec/akasha/event_router_base_spec.rb
+++ b/spec/akasha/event_router_base_spec.rb
@@ -18,9 +18,11 @@ describe Akasha::EventRouterBase do
     end
 
     it 'ignores exceptions' do
-      expect_any_instance_of(Notifier).to receive(:on_name_changed).with('item-1', new_name: 'new name')
+      expect_any_instance_of(Notifier).to receive(:on_name_changed)
+        .with('item-1', new_name: 'new name')
         .and_raise('Oops!')
-      expect_any_instance_of(ItemLogger).to receive(:on_name_changed).with('item-1', new_name: 'new name')
+      expect_any_instance_of(ItemLogger).to receive(:on_name_changed)
+        .with('item-1', new_name: 'new name')
         .and_raise('Oops!')
       expect { subject }.to_not raise_error
     end

--- a/spec/akasha/event_spec.rb
+++ b/spec/akasha/event_spec.rb
@@ -1,19 +1,26 @@
 describe Akasha::Event do
-  subject { described_class.new(:post_created, id, now, foo: 'bar') }
+  let(:event) { described_class.new(:post_created, id, foo: 'bar') }
   let(:id) { '49a122d1-6cbb-490c-857b-ebf473032bc5' }
   let(:now) { Time.now.utc }
 
   describe '#==' do
-    let(:identical) { described_class.new(:post_created, id, now, foo: 'bar') }
-    let(:different_name) { described_class.new(:post_deleted, id, now, foo: 'bar') }
-    let(:different_data) { described_class.new(:post_created, id, now, foo: 'NOT BAR') }
-    let(:identical) { described_class.new(:post_created, id, now, foo: 'bar') }
-    let(:different_creation_time) { described_class.new(:post_created, id, now - 1, foo: 'bar') }
+    subject { event }
+    let(:identical) { described_class.new(:post_created, id, foo: 'bar') }
+    let(:different_name) { described_class.new(:post_deleted, id, foo: 'bar') }
+    let(:different_data) { described_class.new(:post_created, id, foo: 'NOT BAR') }
+    let(:identical) { described_class.new(:post_created, id, foo: 'bar') }
+    let(:different_metadata) { described_class.new(:post_created, id, { baz: 'qux' }, foo: 'bar') }
 
     it { is_expected.to eq(subject) }
     it { is_expected.to eq(identical) }
     it { is_expected.to_not eq(different_name) }
     it { is_expected.to_not eq(different_data) }
-    it { is_expected.to_not eq(different_creation_time) }
+    it { is_expected.to_not eq(different_metadata) }
+  end
+
+  describe '#metadata' do
+    subject { event.metadata }
+
+    it { is_expected.to be_a Hash }
   end
 end

--- a/spec/akasha/storage/http_event_store/event_serializer_spec.rb
+++ b/spec/akasha/storage/http_event_store/event_serializer_spec.rb
@@ -2,7 +2,8 @@ describe Akasha::Storage::HttpEventStore::EventSerializer do
   let(:events) do
     [
       Akasha::Event.new(:name_changed, old_name: nil, new_name: 'new name'),
-      Akasha::Event.new(:name_changed, old_name: 'new_name', new_name: 'newest name')
+      Akasha::Event.new(:name_changed, old_name: 'new_name', new_name: 'newest name'),
+      Akasha::Event.new(:name_changed, { foo: 'bar' }, baz: 'qux')
     ]
   end
 

--- a/spec/akasha/storage/http_event_store/stream_spec.rb
+++ b/spec/akasha/storage/http_event_store/stream_spec.rb
@@ -4,7 +4,7 @@ describe Akasha::Storage::HttpEventStore::Stream, integration: true do
 
   let(:events) do
     [
-      Akasha::Event.new(:things_happened, event_id, OpenStruct.new(foo: 'bar'), bar: 'baz'),
+      Akasha::Event.new(:things_happened, event_id, { foo: 'bar' }, bar: 'baz'),
       Akasha::Event.new(:something_changed)
     ]
   end
@@ -32,13 +32,7 @@ describe Akasha::Storage::HttpEventStore::Stream, integration: true do
 
     it 'persists metadata' do
       subject.write_events(events)
-      expect(subject.read_events(0, 1).first.metadata.foo).to eq 'bar'
-    end
-
-    it 'persists metadata after assignment' do
-      events[0].metadata.foo = 'BAR'
-      subject.write_events(events)
-      expect(subject.read_events(0, 1).first.metadata.foo).to eq 'BAR'
+      expect(subject.read_events(0, 1).first.metadata).to eq(foo: 'bar')
     end
   end
 


### PR DESCRIPTION
> Diff to #9 https://github.com/bilus/akasha/compare/bilus/asynchronous-event-listeners...bilus/refactor-api

1. Simplify event/command router initialization:

Alternative without cleverness:

```ruby
    # Aggregates will load from and save to in-memory storage.
    repository = Akasha::Repository.new(Akasha::Storage::HttpEventStore.new(username: 'admin', password: 'changeit'), 
                                        namespace: :my_app)
    Akasha::Aggregate.connect!(repository)

    # Set up event listeners.
    event_router = Akasha::EventRouter.new(
      user_signed_up: UserListMaterializer
    )
    event_router.connect!(repository)

    async_event_router = Akasha::AsyncEventRouter.new(
      user_signed_up: Notifier
    )
    async_event_router.connect!(repository) # Returns Thread instance.

    @command_router = Akasha::CommandRouter.new(
      sign_up: User,
      sign_up_admin: ->(aggregate_id, **data) {
        user = User.find_or_create(aggregate_id)
        user.sign_up(email: data[:email], password: data[:password], admin: true)
        user.save!
      }
    )
```

2. Change `Event#metadata` to a hash.