### PR TITLE
Support for optional namespaces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,5 @@ Metrics/MethodLength:
   Max: 15
 Rails/Output:
   Enabled: false
+Style/FormatStringToken:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version xx
+
+* Optional namespacing for aggregate/projection streams and events allowing for isolation
+  between applications. [#12](https://github.com/bilus/akasha/pull/12)
+
+
 ## Version 0.3.0
 
 * Asynchronous event listeners (`AsyncEventRouter`). [#9](https://github.com/bilus/akasha/pull/9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Optional namespacing for aggregate/projection streams and events allowing for isolation
   between applications. [#12](https://github.com/bilus/akasha/pull/12)
+* Fix Unhandled events in stream break aggregate loading. [Issue #5](https://github.com/bilus/akasha/issues/5)
 
 
 ## Version 0.3.0

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This library itself makes no assumptions about any web framework, you can use it
   - [x] Hash-based event and command router
   - [x] Assymetry between data and metadata
   - [x] Faster shutdown
-- [ ] Namespacing for events and aggregates and the projection
+- [x] Namespacing for events and aggregates and the projection
 - [ ] Way to control the number of retries in face of network failures
 - [ ] Version-based concurrency
 - [ ] Telemetry (Dogstatsd)

--- a/README.md
+++ b/README.md
@@ -30,23 +30,23 @@ This library itself makes no assumptions about any web framework, you can use it
 - [x] HTTP Eventstore storage backend
 - [x] Event#id for better idempotence (validate this claim)
 - [x] Async EventHandlers (storing cursors in Eventstore, configurable durability guarantees)
-  - [x] Uniform intetrface for Client -- use Event.
+  - [x] Uniform interface for Client -- use Event.
   - [x] Rewrite Client
   - [x] Refactor Client code
   - [x] Take care of created_at/updated_at (saved_at?)
   - [x] Tests for HttpEventStore
   - [x] Projections
   - [x] Test for AsyncEventRouter using events not aggregate
-  - [x] BUG: Projection reorders events
+  - [x] BUG: Projection reorders events (need to use fromAll after all)
   - [x] Simplify AsyncEventRouter init
   - [x] SyncEventRouter => EventRouter
   - [x] Metadata not persisted
 - [x] Refactoring & simplification.
   - [x] Hash-based event and command router
-  - [x] Do we need EventListener class? Yes.
-  - [x] Assymetry between data and metadata.
-  - [x] Faster shutdown.
+  - [x] Assymetry between data and metadata
+  - [x] Faster shutdown
 - [ ] Namespacing for events and aggregates and the projection
+- [ ] Way to control the number of retries in face of network failures
 - [ ] Version-based concurrency
 - [ ] Telemetry (Dogstatsd)
 - [ ] Socket-based Eventstore storage backend

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -57,7 +57,7 @@ class MyAkashaApp
         username: 'admin',
         password: 'changeit'
       ),
-      namespace: :my_app
+      namespace: :'sinatra.example.akasha.bilus.io'
     )
     Akasha::Aggregate.connect!(repository)
 

--- a/lib/akasha/aggregate.rb
+++ b/lib/akasha/aggregate.rb
@@ -29,7 +29,8 @@ module Akasha
     # Used by Repository.
     def apply_events(events)
       events.each do |event|
-        send(event_handler(event), event.data)
+        method_name = event_handler(event)
+        send(method_name, event.data) if respond_to?(method_name)
       end
     end
 

--- a/lib/akasha/async_event_router.rb
+++ b/lib/akasha/async_event_router.rb
@@ -9,13 +9,16 @@ module Akasha
     DEFAULT_PAGE_SIZE = 20
     DEFAULT_PROJECTION_STREAM = 'AsyncEventRouter'.freeze
     DEFAULT_CHECKPOINT_STRATEGY = Akasha::Checkpoint::HttpEventStoreCheckpoint
+    STREAM_NAME_SEP = '-'.freeze
 
-    def connect!(repository, projection_name: DEFAULT_PROJECTION_STREAM,
+    def connect!(repository, projection_name: nil,
                  checkpoint_strategy: DEFAULT_CHECKPOINT_STRATEGY,
                  page_size: DEFAULT_PAGE_SIZE, poll: DEFAULT_POLL_SECONDS)
+      projection_name = projection_name(repository) if projection_name.nil?
       projection_stream = repository.store.streams[projection_name]
       checkpoint = checkpoint_strategy.is_a?(Class) ? checkpoint_strategy.new(projection_stream) : checkpoint_strategy
-      repository.merge_all_by_event(into: projection_name, only: registered_event_names)
+      repository.merge_all_by_event(into: projection_name,
+                                    only: registered_event_names)
       Thread.new do
         run_forever(projection_stream, checkpoint, page_size, poll)
       end
@@ -39,6 +42,13 @@ module Akasha
           end
         end
       end
+    end
+
+    def projection_name(repository)
+      parts = []
+      parts << repository.namespace unless repository.namespace.nil?
+      parts << DEFAULT_PROJECTION_STREAM
+      parts.join(STREAM_NAME_SEP)
     end
   end
 end

--- a/lib/akasha/event.rb
+++ b/lib/akasha/event.rb
@@ -20,5 +20,9 @@ module Akasha
         data == other.data &&
         metadata == other.metadata
     end
+
+    def with_metadata(metadata)
+      Event.new(@name, @id, @metadata.merge(metadata), **@data)
+    end
   end
 end

--- a/lib/akasha/storage/http_event_store.rb
+++ b/lib/akasha/storage/http_event_store.rb
@@ -50,8 +50,10 @@ module Akasha
       # Arguments:
       #   `into` - name of the new stream
       #   `only` - array of event names
-      def merge_all_by_event(into:, only:)
-        @client.merge_all_by_event(into, only)
+      #   `namespace` - optional namespace; if provided, the resulting stream will
+      #                 only contain events with the same metadata.namespace
+      def merge_all_by_event(into:, only:, namespace: nil)
+        @client.merge_all_by_event(into, only, namespace: namespace)
       end
     end
   end

--- a/lib/akasha/storage/http_event_store/client.rb
+++ b/lib/akasha/storage/http_event_store/client.rb
@@ -56,9 +56,12 @@ module Akasha
         # Arguments:
         #   `name` - name of the projection stream
         #   `event_names` - array of event names
-        def merge_all_by_event(name, event_names, max_retries: 0)
+        #   `namespace` - optional namespace; if provided, the resulting stream will
+        #                 only contain events with the same metadata.namespace
+        #   `max_retries` - how many times to retry in case of network failures
+        def merge_all_by_event(name, event_names, namespace: nil, max_retries: 0)
           retrying_on_network_failures(max_retries) do
-            ProjectionManager.new(self).merge_all_by_event(name, event_names)
+            ProjectionManager.new(self).merge_all_by_event(name, event_names, namespace: namespace)
           end
         end
 

--- a/lib/akasha/storage/http_event_store/projection_manager.rb
+++ b/lib/akasha/storage/http_event_store/projection_manager.rb
@@ -14,32 +14,53 @@ module Akasha
         # Arguments:
         #   `name` - name of the projection stream
         #   `event_names` - array of event names
-        def merge_all_by_event(name, event_names)
-          attempt_create_projection(name, event_names) ||
-            update_projection(name, event_names)
+        #   `namespace` - optional namespace; if provided, the resulting stream will
+        #                 only contain events with the same metadata.namespace
+        def merge_all_by_event(name, event_names, namespace: nil)
+          attempt_create_projection(name, event_names, namespace) ||
+            update_projection(name, event_names, namespace)
         end
 
         private
 
-        def projection_javascript(name, events)
-          callbacks = events.map { |en| "\"#{en}\": function(s,e) { linkTo('#{name}', e) }" }
+        # rubocop:disable Metrics/MethodLength
+        def projection_javascript(name, events, namespace)
+          callback_fmt = if namespace.nil?
+                           <<~JS
+                             '%{en}': function(s, e) {
+                               linkTo('%{name}', e)
+                             }
+                           JS
+                         else
+                           <<~JS
+                             '%{en}': function(s, e) {
+                               if (e['metadata'] !== null && e['metadata']['namespace'] === '%{namespace}') {
+                                 linkTo('%{name}', e)
+                               }
+                             }
+                           JS
+                         end
+          callbacks = events.map { |en| format(callback_fmt, en: en, name: name, namespace: namespace) }
+
           # Alternative code using internal indexing.
           # It's broken though because it reorders events for aggregates (because the streams
           # it uses are per-event). An alternative would be to use aggregates as streams
           # to pull from.
           # et_streams = events.map { |en| "\"$et-#{en}\"" }
           # "fromStreams([#{et_streams.join(', ')}]).when({ #{callbacks.join(', ')} });"
-          ''"
-          // This is hard to find, so I'm leaving it here:
-          // options({
-          //   reorderEvents: true,
-          //   processingLag: 100 //time in ms
-          // });
-          fromAll().when({ #{callbacks.join(', ')} });
-          "''
+          <<~JS
+            // This is hard to find, so I'm leaving it here:
+            // options({
+            //   reorderEvents: true,
+            //   processingLag: 100 //time in ms
+            // });
+            fromAll().when({
+              #{callbacks.join(', ')}
+            });
+          JS
         end
 
-        def attempt_create_projection(name, event_names)
+        def attempt_create_projection(name, event_names, namespace)
           create_options = {
             name: name,
             emit: :yes,
@@ -48,7 +69,7 @@ module Akasha
           }
           query_string = Rack::Utils.build_query(create_options)
           @client.request(:post, "/projections/continuous?#{query_string}",
-                          projection_javascript(name, event_names),
+                          projection_javascript(name, event_names, namespace),
                           'Content-Type' => 'application/javascript')
           true
         rescue HttpClientError => e
@@ -56,9 +77,9 @@ module Akasha
           raise
         end
 
-        def update_projection(name, event_names)
+        def update_projection(name, event_names, namespace)
           @client.request(:put, "/projection/#{name}/query?emit=yet",
-                          projection_javascript(name, event_names),
+                          projection_javascript(name, event_names, namespace),
                           'Content-Type' => 'application/javascript')
         end
       end

--- a/lib/akasha/storage/memory_event_store.rb
+++ b/lib/akasha/storage/memory_event_store.rb
@@ -26,9 +26,14 @@ module Akasha
       # Arguments:
       #   `new_stream_name` - name of the new stream
       #   `only` - array of event names
-      def merge_all_by_event(into:, only:)
+      #   `namespace` - optional namespace; if provided, the resulting stream will
+      #                 only contain events with the same metadata.namespace
+      def merge_all_by_event(into:, only:, namespace: nil)
         new_stream = Stream.new do |new_events|
-          new_events.select { |event| only.include?(event.name) }
+          new_events.select do |event|
+            (namespace.nil? || namespace == event.metadata[:namespace]) &&
+              only.include?(event.name)
+          end
         end
         @streams[into] = new_stream
         @projections << new_stream

--- a/spec/akasha/aggregate_spec.rb
+++ b/spec/akasha/aggregate_spec.rb
@@ -54,5 +54,24 @@ describe Akasha::Aggregate do
       item.apply_events(events)
       expect(item.name).to eq 'newest name'
     end
+
+    context 'given events without corresponding on_xx handlers' do
+      let(:events) do
+        [
+          Akasha::Event.new(:name_changed, old_name: nil, new_name: 'new name'),
+          Akasha::Event.new(:unexpected_happened),
+          Akasha::Event.new(:name_changed, old_name: 'new_name', new_name: 'newest name')
+        ]
+      end
+
+      it 'raises no errors' do
+        expect { item.apply_events(events) }.to_not raise_error
+      end
+
+      it 'applies all recognized events' do
+        item.apply_events(events)
+        expect(item.name).to eq 'newest name'
+      end
+    end
   end
 end

--- a/spec/akasha/async_event_router_spec.rb
+++ b/spec/akasha/async_event_router_spec.rb
@@ -1,58 +1,71 @@
 
 # TODO: Simplify initialization!
 describe Akasha::AsyncEventRouter, integration: true do
-  let(:repository) { Akasha::Repository.new(store) }
+  let(:repository) { Akasha::Repository.new(store, namespace: unique_namespace) }
+  let(:unique_namespace) { SecureRandom.uuid }
   let(:store) { Akasha::Storage::HttpEventStore.new(http_es_config) }
-  let(:projection_name) { gensym(:projection) }
-  let(:stream_name) { gensym(:stream) }
-  let(:name_changed_event) { gensym(:name_changed) }
-  let(:something_happened_event) { gensym(:something_happened) }
-  let(:ignored_event) { gensym(:ignored_event) }
-
-  let(:events) do
-    [
-      Akasha::Event.new(name_changed_event, old_name: nil, new_name: 'new name'),
-      Akasha::Event.new(something_happened_event),
-      Akasha::Event.new(name_changed_event, old_name: 'new_name', new_name: 'newest name'),
-      Akasha::Event.new(ignored_event)
-    ]
-  end
+  let(:item) { Item.new('item-1') }
 
   before do
     Akasha::Aggregate.connect!(repository)
-    subject.register_event_listener(name_changed_event, listener)
-    subject.register_event_listener(something_happened_event, listener)
-    @thread = subject.connect!(repository, projection_name: projection_name)
+    subject.register_event_listener(:name_changed, listener)
+    subject.register_event_listener(:count_changed, listener)
+    @thread = subject.connect!(repository)
   end
 
   after do
     @thread.kill
   end
 
-  context 'listener handling name_changed and something_happened' do
+  context 'listener handling name_changed and count_changed' do
     let(:listener) { FakeEventListener.new }
 
+    before do
+      item.name = 'new name'
+      item.count = 5
+      item.name = 'newest name'
+      item.save!
+    end
+
     it 'routes events to listeners' do
-      store.streams[stream_name].write_events(events)
       wait(10).for { listener.calls.size }.to eq 3
     end
 
     it 'preserves ordering' do
-      store.streams[stream_name].write_events(events)
-      expected_calls = [
-        :"on_#{name_changed_event}",
-        :"on_#{something_happened_event}",
-        :"on_#{name_changed_event}"
+      expected_calls = %i[
+        on_name_changed
+        on_count_changed
+        on_name_changed
       ]
       wait(10).for { listener.calls }.to eq expected_calls
     end
+
+    context 'for events within another namespace' do
+      let(:another_namespace) { SecureRandom.uuid }
+      let(:another_repo) { Akasha::Repository.new(store, namespace: another_namespace) }
+
+      it 'ignores those events' do
+        Akasha::Aggregate.connect!(another_repo)
+        item.name = 'different name'
+        item.count = 555
+        item.save!
+
+        wait(10).for { listener.calls.size }.to eq 3
+      end
+    end
   end
 
-  context 'listener failing for something_happened' do
-    let(:listener) { FakeEventListener.new(fail_on: [something_happened_event]) }
+  context 'listener failing for count_changed' do
+    let(:listener) { FakeEventListener.new(fail_on: [:count_changed]) }
+
+    before do
+      item.name = 'new name'
+      item.count = 5
+      item.name = 'newest name'
+      item.save!
+    end
 
     it 'handles the remaining two events' do
-      store.streams[stream_name].write_events(events)
       wait(10).for { listener.calls.size }.to eq 2
     end
   end

--- a/spec/akasha/repository_spec.rb
+++ b/spec/akasha/repository_spec.rb
@@ -23,14 +23,30 @@ describe Akasha::Repository do
     end
 
     context 'for an existing aggregate' do
-      before do
-        item.name = 'foo'
-        subject.save_aggregate(item)
+      context 'within the same namespace' do
+        before do
+          item.name = 'foo'
+          subject.save_aggregate(item)
+        end
+
+        it 'loads the aggregate' do
+          item = subject.load_aggregate(Item, 'item-1')
+          expect(item.name).to eq 'foo'
+        end
       end
 
-      it 'loads the aggregate' do
-        item = subject.load_aggregate(Item, 'item-1')
-        expect(item.name).to eq 'foo'
+      context 'within a different namespace' do
+        let(:another_repo) { described_class.new(store, namespace: 'another.namespace') }
+
+        before do
+          item.name = 'foo'
+          another_repo.save_aggregate(item)
+        end
+
+        it 'returns a new aggregate' do
+          item = subject.load_aggregate(Item, 'item-1')
+          expect(item.name).to be_nil
+        end
       end
     end
   end

--- a/spec/akasha/storage/memory_event_store_spec.rb
+++ b/spec/akasha/storage/memory_event_store_spec.rb
@@ -15,14 +15,36 @@ describe Akasha::Storage::MemoryEventStore do
       ]
     end
 
-    before do
-      subject.merge_all_by_event(into: stream_name, only: %i[world_created world_ended])
-      subject.streams['stream-foo'].write_events(events)
+    context 'given no namespace' do
+      before do
+        subject.merge_all_by_event(into: stream_name, only: %i[world_created world_ended])
+        subject.streams['stream-foo'].write_events(events)
+      end
+
+      it 'creates stream containing events with matching names' do
+        event_names = subject.streams[stream_name].read_events(0, 999).map(&:name)
+        expect(event_names).to match_array(%i[world_created world_ended])
+      end
+
+      it 'accepts events regardless of their namespaces' do
+        subject.streams['stream-foo'].write_events(events.map { |e| e.with_metadata(namespace: 'another.namespace') })
+        event_names = subject.streams[stream_name].read_events(0, 999).map(&:name)
+        expect(event_names).to match_array(%i[world_created world_ended world_created world_ended])
+      end
     end
 
-    it 'creates stream containing events with matching names' do
-      event_names = subject.streams[stream_name].read_events(0, 999).map(&:name).uniq
-      expect(event_names).to match_array(%i[world_created world_ended])
+    context 'if namespace given' do
+      before do
+        subject.merge_all_by_event(into: stream_name, only: %i[world_created world_ended],
+                                   namespace: 'some.namespace')
+        subject.streams['stream-foo'].write_events(events.map { |e| e.with_metadata(namespace: 'some.namespace') })
+        subject.streams['stream-foo'].write_events(events) # These should be ignored.
+      end
+
+      it 'creates stream containing events with matching names and metadata.namespace' do
+        event_names = subject.streams[stream_name].read_events(0, 999).map(&:name)
+        expect(event_names).to match_array(%i[world_created world_ended])
+      end
     end
   end
 end

--- a/spec/fixtures/item.rb
+++ b/spec/fixtures/item.rb
@@ -1,10 +1,14 @@
 # An example aggregate.
 class Item < Akasha::Aggregate
-  attr_reader :name
+  attr_reader :name, :count
 
   # Attribute accessors can use events too!
   def name=(new_name)
     changeset.append(:name_changed, old_name: @name, new_name: new_name)
+  end
+
+  def count=(new_count)
+    changeset.append(:count_changed, old_count: @count, new_count: new_count)
   end
 
   # Alias for default command routing.
@@ -15,5 +19,9 @@ class Item < Akasha::Aggregate
   # This is how you apply events to build aggregate state.
   def on_name_changed(new_name:, **)
     @name = new_name
+  end
+
+  def on_count_changed(new_count:, **)
+    @count = new_count
   end
 end


### PR DESCRIPTION
# Overview

Optional namespacing for aggregate/projection streams and events allowing for isolation between different applications.

As a result, aggregates event listeners will load events generated within the namespace. If no namespace is provided, identical event or aggregate names may result in undefined behavior.

# Usage

```ruby
Akasha::Repository.new(store, namespace: 'myapp.example.com')
```

# Implementation

If a namespace name is provided:

1. Aggregate streams are prefixed with the namespace.
2. Projection stream is prefixed with the namespace.
3. Every event's metadata contains the `namespace` attribute containing the namespace name.
4. Event listeners ignore events with a different `namespace` in their metadata.