### PR TITLE
Configurable retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Version 0.4.0.edge2
+
+* Control the maximum number of retries in case of network related failures. [#14](https://github.com/bilus/akasha/pull/14)
+  Example:
+
+   ```ruby
+   store = Akasha::Storage::HttpEventStore.new(..., max_retries: 10)
+   ```
+
+
 ## Version 0.4.0.edge1
 
 * Optional namespacing for aggregate/projection streams and events allowing for isolation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akasha (0.4.0.edge1)
+    akasha (0.4.0.edge2)
       corefines (~> 1.11)
       faraday (~> 0.15)
       faraday_middleware

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This library itself makes no assumptions about any web framework, you can use it
   - [x] Assymetry between data and metadata
   - [x] Faster shutdown
 - [x] Namespacing for events and aggregates and the projection
-- [ ] Way to control the number of retries in face of network failures
+- [x] Way to control the number of retries in face of network failures
 - [ ] Version-based concurrency
 - [ ] Telemetry (Dogstatsd)
 - [ ] Socket-based Eventstore storage backend

--- a/lib/akasha/storage/http_event_store.rb
+++ b/lib/akasha/storage/http_event_store.rb
@@ -6,10 +6,12 @@ module Akasha
   module Storage
     # HTTP-based interface to Eventstore (https://geteventstore.com)
     class HttpEventStore
-      # Creates a new event store client, connecting to the specified host and port
-      # using an optional username and password.
-      def initialize(host: 'localhost', port: 2113, username: nil, password: nil)
+      # Creates a new event store client, connecting to the specified `host` and `port`
+      # using an optional `username` and `password`.
+      # Use the `max_retries` option to choose how many times to retry in case of network failures.
+      def initialize(host: 'localhost', port: 2113, username: nil, password: nil, max_retries: 0)
         @client = Client.new(host: host, port: port, username: username, password: password)
+        @max_retries = max_retries
       end
 
       # Returns a Hash of streams. You can retrieve a Stream instance corresponding
@@ -21,7 +23,7 @@ module Akasha
 
       # Shortcut for accessing streams by their names.
       def [](stream_name)
-        Stream.new(@client, stream_name)
+        Stream.new(@client, stream_name, max_retries: @max_retries)
       end
 
       # Merges all streams into one, filtering the resulting stream
@@ -32,9 +34,9 @@ module Akasha
       #   `into` - name of the new stream
       #   `only` - array of event names
       #   `namespace` - optional namespace; if provided, the resulting stream will
-      #                 only contain events with the same metadata.namespace
+      #                 only contain events with the same `metadata[:namespace]`
       def merge_all_by_event(into:, only:, namespace: nil)
-        @client.merge_all_by_event(into, only, namespace: namespace)
+        @client.merge_all_by_event(into, only, namespace: namespace, max_retries: @max_retries)
       end
     end
   end

--- a/lib/akasha/storage/http_event_store.rb
+++ b/lib/akasha/storage/http_event_store.rb
@@ -1,30 +1,11 @@
 require_relative 'http_event_store/client'
 require_relative 'http_event_store/stream'
+require_relative 'http_event_store/exceptions'
 
 module Akasha
   module Storage
     # HTTP-based interface to Eventstore (https://geteventstore.com)
     class HttpEventStore
-      # Base class for all HTTP Event store errors.
-      Error = Class.new(RuntimeError)
-      # Stream name contains invalid characters.
-      InvalidStreamNameError = Class.new(Error)
-
-      # Base class for HTTP errors.
-      class HttpError < Error
-        attr_reader :status_code
-
-        def initialize(status_code)
-          @status_code = status_code
-          super("Unexpected HTTP response: #{@status_code}")
-        end
-      end
-
-      # 4xx HTTP status code.
-      HttpClientError = Class.new(HttpError)
-      # 5xx HTTP status code.
-      HttpServerError = Class.new(HttpError)
-
       # Creates a new event store client, connecting to the specified host and port
       # using an optional username and password.
       def initialize(host: 'localhost', port: 2113, username: nil, password: nil)

--- a/lib/akasha/storage/http_event_store/client.rb
+++ b/lib/akasha/storage/http_event_store/client.rb
@@ -73,9 +73,9 @@ module Akasha
         end
 
         # Updates stream metadata.
-        def retry_write_metadata(stream_name, metadata)
+        def retry_write_metadata(stream_name, metadata, max_retries: 0)
           event = Akasha::Event.new(:stream_metadata_changed, SecureRandom.uuid, metadata)
-          retry_append_to_stream("#{stream_name}/metadata", [event])
+          retry_append_to_stream("#{stream_name}/metadata", [event], max_retries: max_retries)
         end
 
         # Issues a generic request against the API.

--- a/lib/akasha/storage/http_event_store/exceptions.rb
+++ b/lib/akasha/storage/http_event_store/exceptions.rb
@@ -1,0 +1,27 @@
+module Akasha
+  module Storage
+    class HttpEventStore
+      # Base class for all HTTP Event store errors.
+      Error = Class.new(RuntimeError)
+
+      # Stream name contains invalid characters.
+      InvalidStreamNameError = Class.new(Error)
+
+      # Base class for HTTP errors.
+      class HttpError < Error
+        attr_reader :status_code
+
+        def initialize(status_code)
+          @status_code = status_code
+          super("Unexpected HTTP response: #{@status_code}")
+        end
+      end
+
+      # 4xx HTTP status code.
+      HttpClientError = Class.new(HttpError)
+
+      # 5xx HTTP status code.
+      HttpServerError = Class.new(HttpError)
+    end
+  end
+end

--- a/lib/akasha/version.rb
+++ b/lib/akasha/version.rb
@@ -1,3 +1,3 @@
 module Akasha
-  VERSION = '0.4.0.edge1'.freeze
+  VERSION = '0.4.0.edge2'.freeze
 end


### PR DESCRIPTION
Control the maximum number of retries in case of network related failures:

   ```ruby
   store = Akasha::Storage::HttpEventStore.new(..., max_retries: 10)
   ```

> I'll merge the edgex changelog entries into one for 0.4.0 before releasing.
